### PR TITLE
Column option for filters

### DIFF
--- a/lib/kiroshi/filter.rb
+++ b/lib/kiroshi/filter.rb
@@ -23,7 +23,7 @@ module Kiroshi
   #
   # @since 0.1.0
   class Filter
-    attr_reader :filter_key, :match, :table_name
+    attr_reader :filter_key, :match, :table_name, :column
 
     # @!method filter_key
     #   @api private
@@ -46,11 +46,19 @@ module Kiroshi
     #
     #   @return [String, String, nil] the table name or nil if not specified
 
+    # @!method column
+    #   @api private
+    #
+    #   Returns the column name to use in database queries
+    #
+    #   @return [Symbol] the column name to use in database queries
+
     # Creates a new Filter instance
     #
     # @param filter_key [Symbol] the filter key name to identify this filter
     # @param match [Symbol] the matching type, defaults to :exact
     # @param table [String, Symbol, nil] the table name to qualify the attribute, defaults to nil
+    # @param column [Symbol] the column name to use in database queries, defaults to filter_key
     # @option match [Symbol] :exact performs exact matching (default)
     # @option match [Symbol] :like performs partial matching using SQL LIKE
     #
@@ -63,23 +71,27 @@ module Kiroshi
     # @example Creating a filter with table qualification
     #   filter = Kiroshi::Filter.new(:name, table: 'documents')
     #
+    # @example Creating a filter with custom column name
+    #   filter = Kiroshi::Filter.new(:user_name, column: :full_name)
+    #
     # @since 0.1.0
-    def initialize(filter_key, match: :exact, table: nil)
+    def initialize(filter_key, match: :exact, table: nil, column: nil)
       @filter_key = filter_key
       @match = match
       @table_name = table
+      @column = column || filter_key
     end
 
     # Returns the column name to use in database queries
     #
-    # Currently returns the same value as filter_key for backward compatibility.
-    # In the future, this will be configurable via a separate column parameter.
+    # This method provides backward compatibility by delegating to the column attribute.
+    # The column name is used by the filter query classes to build the WHERE clauses.
     #
     # @return [Symbol] the column name to use in database queries
     #
     # @since 0.3.0
     def attribute
-      filter_key
+      column
     end
 
     # Applies the filter to the given scope

--- a/lib/kiroshi/filter.rb
+++ b/lib/kiroshi/filter.rb
@@ -42,7 +42,7 @@ module Kiroshi
     # @!method table_name
     #   @api private
     #
-    #   Returns the table name to qualify the attribute
+    #   Returns the table name to qualify the column
     #
     #   @return [String, String, nil] the table name or nil if not specified
 
@@ -50,7 +50,7 @@ module Kiroshi
     #
     # @param filter_key [Symbol] the filter key name to identify this filter
     # @param match [Symbol] the matching type, defaults to :exact
-    # @param table [String, Symbol, nil] the table name to qualify the attribute, defaults to nil
+    # @param table [String, Symbol, nil] the table name to qualify the column, defaults to nil
     # @param column [Symbol] the column name to use in database queries, defaults to filter_key
     # @option match [Symbol] :exact performs exact matching (default)
     # @option match [Symbol] :like performs partial matching using SQL LIKE
@@ -85,18 +85,6 @@ module Kiroshi
     # @since 0.3.0
     def column
       @column ||= filter_key
-    end
-
-    # Returns the column name to use in database queries
-    #
-    # This method provides backward compatibility by delegating to the column method.
-    # The column name is used by the filter query classes to build the WHERE clauses.
-    #
-    # @return [Symbol] the column name to use in database queries
-    #
-    # @since 0.3.0
-    def attribute
-      column
     end
 
     # Applies the filter to the given scope

--- a/lib/kiroshi/filter.rb
+++ b/lib/kiroshi/filter.rb
@@ -23,7 +23,7 @@ module Kiroshi
   #
   # @since 0.1.0
   class Filter
-    attr_reader :filter_key, :match, :table_name, :column
+    attr_reader :filter_key, :match, :table_name
 
     # @!method filter_key
     #   @api private
@@ -45,13 +45,6 @@ module Kiroshi
     #   Returns the table name to qualify the attribute
     #
     #   @return [String, String, nil] the table name or nil if not specified
-
-    # @!method column
-    #   @api private
-    #
-    #   Returns the column name to use in database queries
-    #
-    #   @return [Symbol] the column name to use in database queries
 
     # Creates a new Filter instance
     #
@@ -79,12 +72,24 @@ module Kiroshi
       @filter_key = filter_key
       @match = match
       @table_name = table
-      @column = column || filter_key
+      @column = column
     end
 
     # Returns the column name to use in database queries
     #
-    # This method provides backward compatibility by delegating to the column attribute.
+    # Uses lazy initialization - defaults to filter_key if no column was specified.
+    # This allows for flexible column mapping while maintaining backward compatibility.
+    #
+    # @return [Symbol] the column name to use in database queries
+    #
+    # @since 0.3.0
+    def column
+      @column ||= filter_key
+    end
+
+    # Returns the column name to use in database queries
+    #
+    # This method provides backward compatibility by delegating to the column method.
     # The column name is used by the filter query classes to build the WHERE clauses.
     #
     # @return [Symbol] the column name to use in database queries

--- a/lib/kiroshi/filter.rb
+++ b/lib/kiroshi/filter.rb
@@ -67,7 +67,7 @@ module Kiroshi
     # @example Creating a filter with custom column name
     #   filter = Kiroshi::Filter.new(:user_name, column: :full_name)
     #
-    # @since 0.1.0
+    # @since 0.3.0
     def initialize(filter_key, match: :exact, table: nil, column: nil)
       @filter_key = filter_key
       @match = match

--- a/lib/kiroshi/filter.rb
+++ b/lib/kiroshi/filter.rb
@@ -23,14 +23,14 @@ module Kiroshi
   #
   # @since 0.1.0
   class Filter
-    attr_reader :attribute, :match, :table_name
+    attr_reader :filter_key, :match, :table_name
 
-    # @!method attribute
+    # @!method filter_key
     #   @api private
     #
-    #   Returns the attribute name to filter by
+    #   Returns the filter key name to identify this filter
     #
-    #   @return [Symbol] the attribute name to filter by
+    #   @return [Symbol] the filter key name to identify this filter
 
     # @!method match
     #   @api private
@@ -48,7 +48,7 @@ module Kiroshi
 
     # Creates a new Filter instance
     #
-    # @param attribute [Symbol] the attribute name to filter by
+    # @param filter_key [Symbol] the filter key name to identify this filter
     # @param match [Symbol] the matching type, defaults to :exact
     # @param table [String, Symbol, nil] the table name to qualify the attribute, defaults to nil
     # @option match [Symbol] :exact performs exact matching (default)
@@ -64,10 +64,22 @@ module Kiroshi
     #   filter = Kiroshi::Filter.new(:name, table: 'documents')
     #
     # @since 0.1.0
-    def initialize(attribute, match: :exact, table: nil)
-      @attribute = attribute
+    def initialize(filter_key, match: :exact, table: nil)
+      @filter_key = filter_key
       @match = match
       @table_name = table
+    end
+
+    # Returns the column name to use in database queries
+    #
+    # Currently returns the same value as filter_key for backward compatibility.
+    # In the future, this will be configurable via a separate column parameter.
+    #
+    # @return [Symbol] the column name to use in database queries
+    #
+    # @since 0.3.0
+    def attribute
+      filter_key
     end
 
     # Applies the filter to the given scope

--- a/lib/kiroshi/filter_query.rb
+++ b/lib/kiroshi/filter_query.rb
@@ -94,7 +94,7 @@ module Kiroshi
     #
     #   @return [Kiroshi::FilterRunner] the filter runner instance
 
-    delegate :scope, :attribute, :table_name, :value, to: :filter_runner
+    delegate :scope, :column, :table_name, :value, to: :filter_runner
 
     # @!method scope
     #   @api private
@@ -103,12 +103,12 @@ module Kiroshi
     #
     #   @return [ActiveRecord::Relation] the scope
 
-    # @!method attribute
+    # @!method column
     #   @api private
     #
-    #   Returns the attribute name to filter by
+    #   Returns the column name to use in database queries
     #
-    #   @return [Symbol] the attribute name
+    #   @return [Symbol] the column name
 
     # @!method table_name
     #   @api private

--- a/lib/kiroshi/filter_query/exact.rb
+++ b/lib/kiroshi/filter_query/exact.rb
@@ -13,14 +13,14 @@ module Kiroshi
     # @example Applying exact match query
     #   query = Kiroshi::FilterQuery::Exact.new(filter_runner)
     #   query.apply
-    #   # Generates: WHERE attribute = 'value'
+    #       #   # Generates: WHERE table_name.column = value
     #
     # @since 0.1.1
     class Exact < FilterQuery
       # Applies exact match filtering to the scope
       #
       # This method generates a WHERE clause with exact equality matching
-      # for the filter's attribute and value.
+      # for the filter's column and value.
       #
       # @return [ActiveRecord::Relation] the filtered scope with exact match
       #
@@ -31,7 +31,7 @@ module Kiroshi
       #
       # @since 0.1.1
       def apply
-        scope.where(table_name => { attribute => value })
+        scope.where(table_name => { column => value })
       end
     end
   end

--- a/lib/kiroshi/filter_query/exact.rb
+++ b/lib/kiroshi/filter_query/exact.rb
@@ -13,7 +13,7 @@ module Kiroshi
     # @example Applying exact match query
     #   query = Kiroshi::FilterQuery::Exact.new(filter_runner)
     #   query.apply
-    #       #   # Generates: WHERE table_name.column = value
+    #   # Generates: WHERE table_name.column = value
     #
     # @since 0.1.1
     class Exact < FilterQuery

--- a/lib/kiroshi/filter_query/like.rb
+++ b/lib/kiroshi/filter_query/like.rb
@@ -33,7 +33,7 @@ module Kiroshi
       # @since 0.1.1
       def apply
         scope.where(
-          "#{table_name}.#{attribute} LIKE ?",
+          "\"#{table_name}\".\"#{attribute}\" LIKE ?",
           "%#{value}%"
         )
       end

--- a/lib/kiroshi/filter_query/like.rb
+++ b/lib/kiroshi/filter_query/like.rb
@@ -32,10 +32,7 @@ module Kiroshi
       #
       # @since 0.1.1
       def apply
-        scope.where(
-          sql_query,
-          "%#{value}%"
-        )
+        scope.where(sql_query, "%#{value}%")
       end
 
       private

--- a/lib/kiroshi/filter_query/like.rb
+++ b/lib/kiroshi/filter_query/like.rb
@@ -49,11 +49,11 @@ module Kiroshi
       #
       # @example Generated SQL fragment
       #   sql_query # => '    # Constructs the parameterized SQL query string for column matching
-    #
-    # @return [String] The SQL query string with placeholders
-    # @example
-    #   sql_query
-    #   # Returns: '"table_name"."column" LIKE ?''
+      #
+      # @return [String] The SQL query string with placeholders
+      # @example
+      #   sql_query
+      #   # Returns: '"table_name"."column" LIKE ?''
       #
       # @since 0.3.0
       def sql_query

--- a/lib/kiroshi/filter_query/like.rb
+++ b/lib/kiroshi/filter_query/like.rb
@@ -13,7 +13,7 @@ module Kiroshi
     # @example Applying LIKE match query
     #   query = Kiroshi::FilterQuery::Like.new(filter_runner)
     #   query.apply
-    #   # Generates: WHERE "table_name"."attribute" LIKE '%value%'
+    #   # Generates: WHERE "table_name"."column" LIKE '%value%'
     #
     # @since 0.1.1
     class Like < FilterQuery
@@ -48,12 +48,17 @@ module Kiroshi
       # @return [String] the SQL query fragment for LIKE matching
       #
       # @example Generated SQL fragment
-      #   sql_query # => '"documents"."name" LIKE ?'
+      #   sql_query # => '    # Constructs the parameterized SQL query string for column matching
+    #
+    # @return [String] The SQL query string with placeholders
+    # @example
+    #   sql_query
+    #   # Returns: '"table_name"."column" LIKE ?''
       #
       # @since 0.3.0
       def sql_query
         <<~SQL.squish
-          "#{table_name}"."#{attribute}" LIKE ?
+          "#{table_name}"."#{column}" LIKE ?
         SQL
       end
     end

--- a/lib/kiroshi/filter_query/like.rb
+++ b/lib/kiroshi/filter_query/like.rb
@@ -13,7 +13,7 @@ module Kiroshi
     # @example Applying LIKE match query
     #   query = Kiroshi::FilterQuery::Like.new(filter_runner)
     #   query.apply
-    #   # Generates: WHERE table_name.attribute LIKE '%value%'
+    #   # Generates: WHERE "table_name"."attribute" LIKE '%value%'
     #
     # @since 0.1.1
     class Like < FilterQuery
@@ -28,18 +28,36 @@ module Kiroshi
       # @example Applying LIKE match
       #   query = Like.new(filter_runner)
       #   query.apply
-      #   # Generates: WHERE documents.name LIKE '%ruby%'
+      #   # Generates: WHERE "documents"."name" LIKE '%ruby%'
       #
       # @since 0.1.1
       def apply
-        query = <<~SQL.squish
-          "#{table_name}"."#{attribute}" LIKE ?
-        SQL
-
         scope.where(
-          query,
+          sql_query,
           "%#{value}%"
         )
+      end
+
+      private
+
+      # @api private
+      # @private
+      #
+      # Builds the SQL query string for LIKE matching
+      #
+      # This method constructs the SQL fragment with proper table and column
+      # qualification using double quotes to avoid conflicts with reserved words.
+      #
+      # @return [String] the SQL query fragment for LIKE matching
+      #
+      # @example Generated SQL fragment
+      #   sql_query # => '"documents"."name" LIKE ?'
+      #
+      # @since 0.3.0
+      def sql_query
+        <<~SQL.squish
+          "#{table_name}"."#{attribute}" LIKE ?
+        SQL
       end
     end
   end

--- a/lib/kiroshi/filter_query/like.rb
+++ b/lib/kiroshi/filter_query/like.rb
@@ -32,8 +32,12 @@ module Kiroshi
       #
       # @since 0.1.1
       def apply
+        query = <<~SQL.squish
+          "#{table_name}"."#{attribute}" LIKE ?
+        SQL
+
         scope.where(
-          "\"#{table_name}\".\"#{attribute}\" LIKE ?",
+          query,
           "%#{value}%"
         )
       end

--- a/lib/kiroshi/filter_runner.rb
+++ b/lib/kiroshi/filter_runner.rb
@@ -136,16 +136,16 @@ module Kiroshi
     #
     #   @return [Kiroshi::Filter] the filter configuration
 
-    delegate :attribute, to: :filter
+    delegate :column, to: :filter
     delegate :table_name, to: :scope, prefix: true
     delegate :table_name, to: :filter, prefix: true
 
-    # @!method attribute
+    # @!method column
     #   @api private
     #
-    #   Returns the attribute name to filter by
+    #   Returns the column name to use in database queries
     #
-    #   @return [Symbol] the attribute name to filter by
+    #   @return [Symbol] the column name to use in database queries
 
     # @!method scope_table_name
     #   @api private

--- a/lib/kiroshi/filters.rb
+++ b/lib/kiroshi/filters.rb
@@ -107,7 +107,7 @@ module Kiroshi
     #   @see Filter#initialize for detailed information about filter options
     #   @see Filters#apply for how these filters are used during query execution
     #
-    #   @since 0.1.0
+    #   @since 0.3.0
 
     # Creates a new Filters instance
     #

--- a/lib/kiroshi/filters.rb
+++ b/lib/kiroshi/filters.rb
@@ -40,9 +40,9 @@ module Kiroshi
 
     extend ClassMethods
 
-    # @method self.filter_by(attribute, **options)
+    # @method self.filter_by(filter_key, **options)
     #   @api public
-    #   @param attribute [Symbol] the attribute name to filter by
+    #   @param filter_key [Symbol] the filter key name to identify this filter
     #   @param options [Hash] additional options passed to {Filter#initialize}
     #   @option options [Symbol] :match (:exact) the matching type
     #     - +:exact+ for exact matching (default)

--- a/lib/kiroshi/filters.rb
+++ b/lib/kiroshi/filters.rb
@@ -49,6 +49,8 @@ module Kiroshi
     #     - +:like+ for partial matching using SQL LIKE with wildcards
     #   @option options [String, Symbol, nil] :table (nil) the table name to qualify the attribute
     #     when dealing with joined tables that have conflicting column names
+    #   @option options [Symbol, nil] :column (nil) the column name to use in database queries,
+    #     defaults to filter_key if not specified
     #
     #   @return [Filter] the new filter instance that was created and registered
     #
@@ -89,6 +91,13 @@ module Kiroshi
     #       filter_by :price_max                             # Maximum price
     #       filter_by :in_stock                              # Availability filter
     #       filter_by :category_name, table: :categories     # Category name via join
+    #     end
+    #
+    #   @example Using custom column names
+    #     class UserFilters < Kiroshi::Filters
+    #       filter_by :full_name, column: :name, match: :like    # Filter key 'full_name' maps to 'name' column
+    #       filter_by :user_email, column: :email                # Filter key 'user_email' maps to 'email' column
+    #       filter_by :account_status, column: :status           # Filter key 'account_status' maps to 'status' column
     #     end
     #
     #   @note When using table qualification, ensure that the specified table

--- a/lib/kiroshi/filters.rb
+++ b/lib/kiroshi/filters.rb
@@ -47,7 +47,7 @@ module Kiroshi
     #   @option options [Symbol] :match (:exact) the matching type
     #     - +:exact+ for exact matching (default)
     #     - +:like+ for partial matching using SQL LIKE with wildcards
-    #   @option options [String, Symbol, nil] :table (nil) the table name to qualify the attribute
+    #   @option options [String, Symbol, nil] :table (nil) the table name to qualify the column
     #     when dealing with joined tables that have conflicting column names
     #   @option options [Symbol, nil] :column (nil) the column name to use in database queries,
     #     defaults to filter_key if not specified
@@ -112,7 +112,7 @@ module Kiroshi
     # Creates a new Filters instance
     #
     # @param filters [Hash] a hash containing the filter values to be applied.
-    #   Keys should correspond to attributes defined with {.filter_by}.
+    #   Keys should correspond to filter keys defined with {.filter_by}.
     #   Values will be used for filtering. Nil or blank values are ignored.
     #
     # @example Creating filters with values
@@ -167,8 +167,8 @@ module Kiroshi
     #
     # @since 0.2.0
     def apply(scope)
-      filters.compact.each do |attribute, value|
-        filter = self.class.filter_for(attribute)
+      filters.compact.each do |filter_key, value|
+        filter = self.class.filter_for(filter_key)
         next unless filter
 
         scope = filter.apply(scope: scope, value: value)

--- a/lib/kiroshi/filters/class_methods.rb
+++ b/lib/kiroshi/filters/class_methods.rb
@@ -85,7 +85,7 @@ module Kiroshi
       # @see .filter_configs for accessing the complete filter registry
       # @see Filters#apply for how this method is used during filtering
       #
-      # @since 0.2.0
+      # @since 0.3.0
       def filter_for(filter_key)
         filter_key_string = filter_key.to_s
         filter_configs[filter_key_string] || inherited_filter_for(filter_key_string)
@@ -105,7 +105,7 @@ module Kiroshi
       # @param filter_key_string [String] the filter key name to look up
       # @return [Filter, nil] the filter instance from a parent class, or nil if not found
       #
-      # @since 0.2.0
+      # @since 0.3.0
       def inherited_filter_for(filter_key_string)
         return nil unless superclass < Kiroshi::Filters
 

--- a/lib/kiroshi/filters/class_methods.rb
+++ b/lib/kiroshi/filters/class_methods.rb
@@ -46,14 +46,16 @@ module Kiroshi
       #     - +:like+ for partial matching using SQL LIKE with wildcards
       #   @option options [String, Symbol, nil] :table (nil) the table name to qualify the attribute
       #     when dealing with joined tables that have conflicting column names
+      #   @option options [Symbol, nil] :column (nil) the column name to use in database queries,
+      #     defaults to filter_key if not specified
       #
       # @return (see Filters.filter_by)
       # @example (see Filters.filter_by)
       # @note (see Filters.filter_by)
       # @see (see Filters.filter_by)
       # @since (see Filters.filter_by)
-      def filter_by(filter_key, **)
-        Filter.new(filter_key, **).tap do |filter|
+      def filter_by(filter_key, **options)
+        Filter.new(filter_key, **options).tap do |filter|
           filter_configs[filter_key.to_s] = filter
         end
       end

--- a/lib/kiroshi/filters/class_methods.rb
+++ b/lib/kiroshi/filters/class_methods.rb
@@ -44,7 +44,7 @@ module Kiroshi
       #   @option options [Symbol] :match (:exact) the matching type
       #     - +:exact+ for exact matching (default)
       #     - +:like+ for partial matching using SQL LIKE with wildcards
-      #   @option options [String, Symbol, nil] :table (nil) the table name to qualify the attribute
+      #   @option options [String, Symbol, nil] :table (nil) the table name to qualify the column
       #     when dealing with joined tables that have conflicting column names
       #   @option options [Symbol, nil] :column (nil) the column name to use in database queries,
       #     defaults to filter_key if not specified
@@ -119,7 +119,7 @@ module Kiroshi
       #
       # This method provides access to the internal registry of filters
       # that have been configured using {.filter_by}. The returned hash
-      # contains {Filter} instances keyed by their attribute names, allowing
+      # contains {Filter} instances keyed by their filter key names, allowing
       # for efficient O(1) lookup during filter application.
       #
       # This method is primarily used internally by {Filters#apply} to
@@ -128,7 +128,7 @@ module Kiroshi
       # and testing purposes.
       #
       # @return [Hash<String, Filter>] hash of {Filter} instances configured
-      #   for this filter class, keyed by attribute name for efficient access
+      #   for this filter class, keyed by filter key name for efficient access
       #
       # @example Accessing configured filters for introspection
       #   class MyFilters < Kiroshi::Filters

--- a/lib/kiroshi/filters/class_methods.rb
+++ b/lib/kiroshi/filters/class_methods.rb
@@ -38,8 +38,8 @@ module Kiroshi
       # options to handle complex database queries with joins and ambiguous
       # column names.
       #
-      # @overload filter_by(attribute, **options)
-      #   @param attribute [Symbol] the attribute name to filter by
+      # @overload filter_by(filter_key, **options)
+      #   @param filter_key [Symbol] the filter key name to identify this filter
       #   @param options [Hash] additional options passed to {Filter#initialize}
       #   @option options [Symbol] :match (:exact) the matching type
       #     - +:exact+ for exact matching (default)
@@ -52,23 +52,23 @@ module Kiroshi
       # @note (see Filters.filter_by)
       # @see (see Filters.filter_by)
       # @since (see Filters.filter_by)
-      def filter_by(attribute, **)
-        Filter.new(attribute, **).tap do |filter|
-          filter_configs[attribute.to_s] = filter
+      def filter_by(filter_key, **)
+        Filter.new(filter_key, **).tap do |filter|
+          filter_configs[filter_key.to_s] = filter
         end
       end
 
       # @api private
-      # Returns the filter configuration for a specific attribute
+      # Returns the filter configuration for a specific filter key
       #
       # This method provides a convenient way to retrieve a specific filter
-      # by its attribute name. It's a shorthand for accessing the filter_configs
+      # by its filter key name. It's a shorthand for accessing the filter_configs
       # hash directly and is used internally by the filtering system.
       #
-      # @param attribute [Symbol, String] the attribute name to look up
+      # @param filter_key [Symbol, String] the filter key name to look up
       #
-      # @return [Filter, nil] the filter instance for the given attribute,
-      #   or nil if no filter is configured for that attribute
+      # @return [Filter, nil] the filter instance for the given filter key,
+      #   or nil if no filter is configured for that filter key
       #
       # @example Retrieving a specific filter
       #   class MyFilters < Kiroshi::Filters
@@ -76,17 +76,17 @@ module Kiroshi
       #     filter_by :status
       #   end
       #
-      #   MyFilters.filter_for(:name)    # => #<Kiroshi::Filter:0x... @attribute=:name @match=:like>
-      #   MyFilters.filter_for(:status)  # => #<Kiroshi::Filter:0x... @attribute=:status @match=:exact>
+      #   MyFilters.filter_for(:name)    # => #<Kiroshi::Filter:0x... @filter_key=:name @match=:like>
+      #   MyFilters.filter_for(:status)  # => #<Kiroshi::Filter:0x... @filter_key=:status @match=:exact>
       #   MyFilters.filter_for(:unknown) # => nil
       #
       # @see .filter_configs for accessing the complete filter registry
       # @see Filters#apply for how this method is used during filtering
       #
       # @since 0.2.0
-      def filter_for(attribute)
-        attribute_key = attribute.to_s
-        filter_configs[attribute_key] || inherited_filter_for(attribute_key)
+      def filter_for(filter_key)
+        filter_key_string = filter_key.to_s
+        filter_configs[filter_key_string] || inherited_filter_for(filter_key_string)
       end
 
       private
@@ -97,17 +97,17 @@ module Kiroshi
       # Searches for a filter in the inheritance chain
       #
       # This method looks up the inheritance chain to find a filter configuration
-      # for the given attribute. It only searches in superclasses that inherit
+      # for the given filter key. It only searches in superclasses that inherit
       # from Kiroshi::Filters, stopping when it reaches a non-Filters class.
       #
-      # @param attribute_key [String] the attribute name to look up
+      # @param filter_key_string [String] the filter key name to look up
       # @return [Filter, nil] the filter instance from a parent class, or nil if not found
       #
       # @since 0.2.0
-      def inherited_filter_for(attribute_key)
+      def inherited_filter_for(filter_key_string)
         return nil unless superclass < Kiroshi::Filters
 
-        superclass.filter_for(attribute_key)
+        superclass.filter_for(filter_key_string)
       end
 
       # @api private

--- a/spec/lib/kiroshi/filter_query/exact_spec.rb
+++ b/spec/lib/kiroshi/filter_query/exact_spec.rb
@@ -270,5 +270,45 @@ RSpec.describe Kiroshi::FilterQuery::Exact, type: :model do
         end
       end
     end
+
+    context 'when Filter#column is different from filter_key' do
+      let(:filter) { Kiroshi::Filter.new(:user_name, match: :exact, column: :full_name) }
+      let(:filter_value) { 'John Doe' }
+
+      let!(:matching_document) { create(:document, full_name: 'John Doe') }
+      let!(:non_matching_document) { create(:document, full_name: 'Jane Smith') }
+
+      let(:expected_sql) do
+        <<~SQL.squish
+          SELECT "documents".* FROM "documents" WHERE "documents"."full_name" = 'John Doe'
+        SQL
+      end
+
+      it 'uses the column name instead of filter_key in SQL' do
+        expect(query.apply.to_sql).to eq(expected_sql)
+      end
+
+      it 'returns records that match the column value' do
+        expect(query.apply).to include(matching_document)
+      end
+
+      it 'does not return records that do not match the column value' do
+        expect(query.apply).not_to include(non_matching_document)
+      end
+
+      context 'with table qualification' do
+        let(:filter) { Kiroshi::Filter.new(:user_name, match: :exact, table: :documents, column: :full_name) }
+
+        let(:expected_sql) do
+          <<~SQL.squish
+            SELECT "documents".* FROM "documents" WHERE "documents"."full_name" = 'John Doe'
+          SQL
+        end
+
+        it 'generates SQL with proper table and column qualification' do
+          expect(query.apply.to_sql).to eq(expected_sql)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/kiroshi/filter_query/like_spec.rb
+++ b/spec/lib/kiroshi/filter_query/like_spec.rb
@@ -269,11 +269,11 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
     end
 
     context 'when Filter#column is different from filter_key' do
-      let(:filter) { Kiroshi::Filter.new(:user_name, match: :like, column: :full_name) }
+      let(:filter)       { Kiroshi::Filter.new(:user_name, match: :like, column: :full_name) }
       let(:filter_value) { 'John' }
 
       let!(:matching_document) { create(:document, full_name: 'John Doe') }
-      let!(:another_match) { create(:document, full_name: 'Johnny Smith') }
+      let!(:another_match)         { create(:document, full_name: 'Johnny Smith') }
       let!(:non_matching_document) { create(:document, full_name: 'Jane Wilson') }
 
       let(:expected_sql) do

--- a/spec/lib/kiroshi/filter_query/like_spec.rb
+++ b/spec/lib/kiroshi/filter_query/like_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
     let(:expected_sql) do
       <<~SQL.squish
-        SELECT "documents".* FROM "documents" WHERE (documents.name LIKE '%test%')
+        SELECT "documents".* FROM "documents" WHERE ("documents"."name" LIKE '%test%')
       SQL
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
       let(:expected_sql) do
         <<~SQL.squish
-          SELECT "documents".* FROM "documents" WHERE (documents.status LIKE '%pub%')
+          SELECT "documents".* FROM "documents" WHERE ("documents"."status" LIKE '%pub%')
         SQL
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
       let(:expected_sql) do
         <<~SQL.squish
-          SELECT "documents".* FROM "documents" WHERE (documents.version LIKE '%1.2%')
+          SELECT "documents".* FROM "documents" WHERE ("documents"."version" LIKE '%1.2%')
         SQL
       end
 
@@ -104,7 +104,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
       let(:expected_sql) do
         <<~SQL.squish
-          SELECT "documents".* FROM "documents" WHERE (documents.name LIKE '%nonexistent%')
+          SELECT "documents".* FROM "documents" WHERE ("documents"."name" LIKE '%nonexistent%')
         SQL
       end
 
@@ -218,7 +218,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
         it 'generates SQL with tags table qualification' do
           result_sql = query.apply.to_sql
-          expect(result_sql).to include('tags.name LIKE')
+          expect(result_sql).to include('"tags"."name" LIKE')
         end
 
         it 'generates SQL with correct LIKE pattern for tag name' do
@@ -245,7 +245,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
         it 'generates SQL with documents table qualification' do
           result_sql = query.apply.to_sql
-          expect(result_sql).to include('documents.name LIKE')
+          expect(result_sql).to include('"documents"."name" LIKE')
         end
 
         it 'generates SQL with correct LIKE pattern for document name' do
@@ -263,7 +263,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
         it 'generates SQL with string table qualification' do
           result_sql = query.apply.to_sql
-          expect(result_sql).to include('tags.name LIKE')
+          expect(result_sql).to include('"tags"."name" LIKE')
         end
       end
     end

--- a/spec/lib/kiroshi/filter_runner_spec.rb
+++ b/spec/lib/kiroshi/filter_runner_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Kiroshi::FilterRunner, type: :model do
       end
 
       it 'generates correct SQL with table name prefix' do
-        expected_sql = "SELECT \"documents\".* FROM \"documents\" WHERE (documents.name LIKE '%test%')"
+        expected_sql = "SELECT \"documents\".* FROM \"documents\" WHERE (\"documents\".\"name\" LIKE '%test%')"
         expect(runner.apply.to_sql).to eq(expected_sql)
       end
     end

--- a/spec/lib/kiroshi/filters/class_methods_spec.rb
+++ b/spec/lib/kiroshi/filters/class_methods_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Kiroshi::Filters::ClassMethods, type: :model do
       it do
         expect { filters_class.filter_by :name, match: :like, table: :documents }
           .to change { filter_instance.apply(scope) }
-          .from(scope).to(scope.where('documents.name LIKE ?', '%test%'))
+          .from(scope).to(scope.where('"documents"."name" LIKE ?', '%test%'))
       end
     end
   end

--- a/spec/lib/kiroshi/filters_spec.rb
+++ b/spec/lib/kiroshi/filters_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
 
         it 'generates SQL with table-qualified LIKE operation' do
           result = filter_instance.apply(scope)
-          expect(result.to_sql).to include('documents.name LIKE')
+          expect(result.to_sql).to include('"documents"."name" LIKE')
         end
 
         it 'generates SQL with correct LIKE pattern' do
@@ -336,7 +336,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
         end
 
         it 'generates SQL with LIKE operation on the specified column' do
-          expect(filter_instance.apply(scope).to_sql).to include('tags.name LIKE')
+          expect(filter_instance.apply(scope).to_sql).to include('"tags"."name" LIKE')
         end
 
         it 'generates SQL with correct LIKE pattern' do

--- a/spec/support/db/schema.rb
+++ b/spec/support/db/schema.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define do
 
   create_table :documents, force: true do |t|
     t.string   :name
+    t.string   :full_name
     t.string   :status
     t.boolean  :active
     t.integer  :priority


### PR DESCRIPTION
## Separate filter key from database column mapping

### Summary
Added support for custom column mapping in filter configuration, allowing the filter identifier to be different from the database column used in queries.

### Changes
- **New `column` parameter**: Added optional `column` parameter to `Filter.new()` and `filter_by()` methods
- **Backward compatibility**: When `column` is not specified, defaults to `filter_key` (lazy initialization)
- **SQL improvements**: Enhanced SQL generation with proper quoted identifiers (`"table"."column"`)
- **Method extraction**: Extracted `sql_query` method in `Like` class for better code organization
- **API cleanup**: Removed deprecated `attribute` method in favor of clear `filter_key`/`column` separation

### Usage Examples

**Before:**
```ruby
filter_by :user_name  # Uses 'user_name' column in database
```

**After:**
```ruby
# Same behavior (backward compatible)
filter_by :user_name

# Custom column mapping
filter_by :user_name, column: :full_name  # Filter key 'user_name', queries 'full_name' column
```

### Migration Guide
- Existing code continues to work without changes
- `Filter#attribute` method removed - use `Filter#column` instead
- All SQL now uses quoted identifiers for better database compatibility

### Version
This introduces breaking changes for internal APIs while maintaining public API compatibility. Bumps version to **0.3.0**.
