### PR TITLE
Fix like query

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 
 ## Yard Documentation
 
-[https://www.rubydoc.info/gems/kiroshi/0.3.0](https://www.rubydoc.info/gems/kiroshi/0.3.0)
+[https://www.rubydoc.info/gems/kiroshi/0.3.1](https://www.rubydoc.info/gems/kiroshi/0.3.1)
 
 Kiroshi has been designed to make filtering ActiveRecord queries easier
 by providing a flexible and reusable filtering system. It allows you to
 define filter sets that can be applied to any ActiveRecord scope,
 supporting both exact matches and partial matching using SQL LIKE operations.
 
-Current Release: [0.3.0](https://github.com/darthjee/kiroshi/tree/0.3.0)
+Current Release: [0.3.1](https://github.com/darthjee/kiroshi/tree/0.3.1)
 
-[Next release](https://github.com/darthjee/kiroshi/compare/0.3.0...master)
+[Next release](https://github.com/darthjee/kiroshi/compare/0.3.1...master)
 
 ## Installation
 

--- a/lib/kiroshi/filter_query/like.rb
+++ b/lib/kiroshi/filter_query/like.rb
@@ -58,7 +58,7 @@ module Kiroshi
       # @since 0.3.0
       def sql_query
         <<~SQL.squish
-          "#{table_name}"."#{column}" LIKE ?
+          `#{table_name}`.`#{column}` LIKE ?
         SQL
       end
     end

--- a/lib/kiroshi/filter_query/like.rb
+++ b/lib/kiroshi/filter_query/like.rb
@@ -13,7 +13,7 @@ module Kiroshi
     # @example Applying LIKE match query
     #   query = Kiroshi::FilterQuery::Like.new(filter_runner)
     #   query.apply
-    #   # Generates: WHERE "table_name"."column" LIKE '%value%'
+    #   # Generates: WHERE `table_name`.`column` LIKE '%value%'
     #
     # @since 0.1.1
     class Like < FilterQuery
@@ -28,7 +28,7 @@ module Kiroshi
       # @example Applying LIKE match
       #   query = Like.new(filter_runner)
       #   query.apply
-      #   # Generates: WHERE "documents"."name" LIKE '%ruby%'
+      #   # Generates: WHERE `documents`.`name` LIKE '%ruby%'
       #
       # @since 0.1.1
       def apply
@@ -43,17 +43,13 @@ module Kiroshi
       # Builds the SQL query string for LIKE matching
       #
       # This method constructs the SQL fragment with proper table and column
-      # qualification using double quotes to avoid conflicts with reserved words.
+      # qualification using backticks to avoid conflicts with reserved words.
       #
       # @return [String] the SQL query fragment for LIKE matching
       #
       # @example Generated SQL fragment
-      #   sql_query # => '    # Constructs the parameterized SQL query string for column matching
-      #
-      # @return [String] The SQL query string with placeholders
-      # @example
       #   sql_query
-      #   # Returns: '"table_name"."column" LIKE ?''
+      #   # Returns: '`table_name`.`column` LIKE ?'
       #
       # @since 0.3.0
       def sql_query

--- a/lib/kiroshi/version.rb
+++ b/lib/kiroshi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kiroshi
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/lib/kiroshi/filter_query/like_spec.rb
+++ b/spec/lib/kiroshi/filter_query/like_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
     let(:expected_sql) do
       <<~SQL.squish
-        SELECT "documents".* FROM "documents" WHERE ("documents"."name" LIKE '%test%')
+        SELECT "documents".* FROM "documents" WHERE (`documents`.`name` LIKE '%test%')
       SQL
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
       let(:expected_sql) do
         <<~SQL.squish
-          SELECT "documents".* FROM "documents" WHERE ("documents"."status" LIKE '%pub%')
+          SELECT "documents".* FROM "documents" WHERE (`documents`.`status` LIKE '%pub%')
         SQL
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
       let(:expected_sql) do
         <<~SQL.squish
-          SELECT "documents".* FROM "documents" WHERE ("documents"."version" LIKE '%1.2%')
+          SELECT "documents".* FROM "documents" WHERE (`documents`.`version` LIKE '%1.2%')
         SQL
       end
 
@@ -104,7 +104,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
       let(:expected_sql) do
         <<~SQL.squish
-          SELECT "documents".* FROM "documents" WHERE ("documents"."name" LIKE '%nonexistent%')
+          SELECT "documents".* FROM "documents" WHERE (`documents`.`name` LIKE '%nonexistent%')
         SQL
       end
 
@@ -218,7 +218,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
         it 'generates SQL with tags table qualification' do
           result_sql = query.apply.to_sql
-          expect(result_sql).to include('"tags"."name" LIKE')
+          expect(result_sql).to include('`tags`.`name` LIKE')
         end
 
         it 'generates SQL with correct LIKE pattern for tag name' do
@@ -245,7 +245,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
         it 'generates SQL with documents table qualification' do
           result_sql = query.apply.to_sql
-          expect(result_sql).to include('"documents"."name" LIKE')
+          expect(result_sql).to include('`documents`.`name` LIKE')
         end
 
         it 'generates SQL with correct LIKE pattern for document name' do
@@ -263,7 +263,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
         it 'generates SQL with string table qualification' do
           result_sql = query.apply.to_sql
-          expect(result_sql).to include('"tags"."name" LIKE')
+          expect(result_sql).to include('`tags`.`name` LIKE')
         end
       end
     end
@@ -278,7 +278,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
       let(:expected_sql) do
         <<~SQL.squish
-          SELECT "documents".* FROM "documents" WHERE ("documents"."full_name" LIKE '%John%')
+          SELECT "documents".* FROM "documents" WHERE (`documents`.`full_name` LIKE '%John%')
         SQL
       end
 
@@ -303,7 +303,7 @@ RSpec.describe Kiroshi::FilterQuery::Like, type: :model do
 
         let(:expected_sql) do
           <<~SQL.squish
-            SELECT "documents".* FROM "documents" WHERE ("documents"."full_name" LIKE '%John%')
+            SELECT "documents".* FROM "documents" WHERE (`documents`.`full_name` LIKE '%John%')
           SQL
         end
 

--- a/spec/lib/kiroshi/filter_runner_spec.rb
+++ b/spec/lib/kiroshi/filter_runner_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Kiroshi::FilterRunner, type: :model do
       end
 
       it 'generates correct SQL with table name prefix' do
-        expected_sql = "SELECT \"documents\".* FROM \"documents\" WHERE (\"documents\".\"name\" LIKE '%test%')"
+        expected_sql = "SELECT \"documents\".* FROM \"documents\" WHERE (`documents`.`name` LIKE '%test%')"
         expect(runner.apply.to_sql).to eq(expected_sql)
       end
     end
@@ -126,7 +126,7 @@ RSpec.describe Kiroshi::FilterRunner, type: :model do
         end
 
         it 'generates correct LIKE SQL using the column name' do
-          expected_sql = "SELECT \"documents\".* FROM \"documents\" WHERE (\"documents\".\"full_name\" LIKE '%John%')"
+          expected_sql = "SELECT \"documents\".* FROM \"documents\" WHERE (`documents`.`full_name` LIKE '%John%')"
           expect(runner.apply.to_sql).to eq(expected_sql)
         end
       end

--- a/spec/lib/kiroshi/filters/class_methods_spec.rb
+++ b/spec/lib/kiroshi/filters/class_methods_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Kiroshi::Filters::ClassMethods, type: :model do
       it do
         expect { filters_class.filter_by :name, match: :like, table: :documents }
           .to change { filter_instance.apply(scope) }
-          .from(scope).to(scope.where('"documents"."name" LIKE ?', '%test%'))
+          .from(scope).to(scope.where('`documents`.`name` LIKE ?', '%test%'))
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Kiroshi::Filters::ClassMethods, type: :model do
         it do
           expect { filters_class.filter_by :user_name, match: :like, column: :full_name }
             .to change { filter_instance.apply(scope) }
-            .from(scope).to(scope.where('"documents"."full_name" LIKE ?', '%John%'))
+            .from(scope).to(scope.where('`documents`.`full_name` LIKE ?', '%John%'))
         end
       end
 
@@ -95,7 +95,7 @@ RSpec.describe Kiroshi::Filters::ClassMethods, type: :model do
         it do
           expect { filters_class.filter_by :tag_identifier, match: :like, table: :tags, column: :name }
             .to change { filter_instance.apply(scope) }
-            .from(scope).to(scope.where('"tags"."name" LIKE ?', '%rub%'))
+            .from(scope).to(scope.where('`tags`.`name` LIKE ?', '%rub%'))
         end
       end
     end

--- a/spec/lib/kiroshi/filters_spec.rb
+++ b/spec/lib/kiroshi/filters_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
 
       it 'generates SQL that includes documents table qualification for name field' do
         result = filter_instance.apply(scope)
-        expect(result.to_sql).to include('`documents`.`name`')
+        expect(result.to_sql).to include('"documents"."name"')
       end
 
       it 'generates SQL that includes the filter value' do
@@ -312,7 +312,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
       end
 
       it 'generates SQL that filters by tags.name using the column parameter' do
-        expect(filter_instance.apply(scope).to_sql).to include('`tags`.`name`')
+        expect(filter_instance.apply(scope).to_sql).to include('"tags"."name"')
       end
 
       it 'generates SQL that includes the filter value' do
@@ -447,7 +447,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
         end
 
         it 'generates SQL that filters by tags.name, not documents.name' do
-          expect(filter_instance.apply(scope).to_sql).to include('`tags`.`name`')
+          expect(filter_instance.apply(scope).to_sql).to include('"tags"."name"')
         end
 
         it 'generates SQL that does not include documents.name' do

--- a/spec/lib/kiroshi/filters_spec.rb
+++ b/spec/lib/kiroshi/filters_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
 
       it 'generates SQL that includes documents table qualification for name field' do
         result = filter_instance.apply(scope)
-        expect(result.to_sql).to include('"documents"."name"')
+        expect(result.to_sql).to include('`documents`.`name`')
       end
 
       it 'generates SQL that includes the filter value' do
@@ -279,7 +279,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
 
         it 'generates SQL with table-qualified LIKE operation' do
           result = filter_instance.apply(scope)
-          expect(result.to_sql).to include('"documents"."name" LIKE')
+          expect(result.to_sql).to include('`documents`.`name` LIKE')
         end
 
         it 'generates SQL with correct LIKE pattern' do
@@ -312,7 +312,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
       end
 
       it 'generates SQL that filters by tags.name using the column parameter' do
-        expect(filter_instance.apply(scope).to_sql).to include('"tags"."name"')
+        expect(filter_instance.apply(scope).to_sql).to include('`tags`.`name`')
       end
 
       it 'generates SQL that includes the filter value' do
@@ -336,7 +336,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
         end
 
         it 'generates SQL with LIKE operation on the specified column' do
-          expect(filter_instance.apply(scope).to_sql).to include('"tags"."name" LIKE')
+          expect(filter_instance.apply(scope).to_sql).to include('`tags`.`name` LIKE')
         end
 
         it 'generates SQL with correct LIKE pattern' do
@@ -353,7 +353,7 @@ RSpec.describe Kiroshi::Filters, type: :model do
 
         it 'uses the column name in database queries' do
           result = filter_instance.apply(Document.all)
-          expect(result.to_sql).to include('"documents"."name"')
+          expect(result.to_sql).to include('`documents`.`name`')
         end
 
         it 'does not use the filter key in SQL' do
@@ -447,11 +447,11 @@ RSpec.describe Kiroshi::Filters, type: :model do
         end
 
         it 'generates SQL that filters by tags.name, not documents.name' do
-          expect(filter_instance.apply(scope).to_sql).to include('"tags"."name"')
+          expect(filter_instance.apply(scope).to_sql).to include('`tags`.`name`')
         end
 
         it 'generates SQL that does not include documents.name' do
-          expect(filter_instance.apply(scope).to_sql).not_to include('"documents"."name"')
+          expect(filter_instance.apply(scope).to_sql).not_to include('`documents`.`name`')
         end
 
         it 'generates SQL that includes the tag filter value' do


### PR DESCRIPTION
## Fix LIKE query SQL formatting to use backticks

### Summary
Fixed SQL identifier formatting in LIKE queries to use backticks (`) instead of double quotes (") for table and column qualification.

### Changes
- **SQL Generation**: Updated `Like#sql_query` to use backticks for MySQL compatibility
- **Test Updates**: Corrected all spec expectations to match new SQL format
- **Documentation**: Updated code examples and comments to reflect backtick usage

### Before
```sql
WHERE "table_name"."column" LIKE '%value%'
```

### After
```sql
WHERE `table_name`.`column` LIKE '%value%'
```

### Impact
- Improved MySQL database compatibility
- Consistent SQL identifier quoting across the codebase
- No breaking changes to public API
